### PR TITLE
Fix for issue 19: add Unicode to Worknik word list

### DIFF
--- a/wordnik/swagger.py
+++ b/wordnik/swagger.py
@@ -97,7 +97,7 @@ class ApiClient:
 
         if not obj:
             return None
-        elif type(obj) in [str, int, long, float, bool]:
+        elif type(obj) in [str, int, long, float, bool, unicode]:
             return obj
         elif type(obj) == list:
             return [self.sanitizeForSerialization(subObj) for subObj in obj]


### PR DESCRIPTION
Trying to add a Unicode to a Wordnik list causes an `AttributeError: 'unicode' object has no attribute '__dict__'`, reported in issue #19.

Here's a fix. 

Tests are in issue #20. They fail before the fix, and pass after the fix.
